### PR TITLE
Update dfn@title for `\s` to match ES 5.1 and Unicode 6.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
 		<dfn title="Character class">[…]</dfn>
 		<dfn title="Same as [a-zA-Z0-9_]">\w</dfn>
 		<dfn title="Same as [0-9]">\d</dfn>
-		<dfn title="About the same as [\t\r\n ]">\s</dfn>
+		<dfn title="Same as [ \t\n\r\f\v\xa0\u2028\u2029\u1680\u180e\u2000-\u200a\u202f\u205f\u3000\ufeff]">\s</dfn>
 		<dfn title="Negated character class" class="long">[^…]</dfn>
 		<dfn title="Grouping and capturing">(…)</dfn>
 		<dfn title="Non-capturing group" class="long">(?:…)</dfn>


### PR DESCRIPTION
http://es5.github.com/x15.10.html#x15.10.2.12:

> The production `CharacterClassEscape :: s` evaluates by returning the set of characters containing the characters that are on the right-hand side of the [`WhiteSpace` (7.2)](http://es5.github.com/x7.html#x7.2) or [`LineTerminator` (7.3)](http://es5.github.com/x7.html#x7.3) productions.

http://es5.github.com/x7.html#x7.2:

> ECMAScript implementations must recognize all of the white space characters defined in Unicode 3.0. Later editions of the Unicode Standard may define other white space characters. ECMAScript implementations may recognize white space characters from later editions of the Unicode Standard.
