### PR TITLE
Stop heading from wrapping to next line in help

### DIFF
--- a/css/standalone.css
+++ b/css/standalone.css
@@ -75,7 +75,7 @@ section.help {
 	section.help h1 {
 		position: absolute;
 		top: -1.1em;
-		font-size: 125%;
+		font-size: 120%;
 		line-height: 1;
 		text-align: center;
 	}


### PR DESCRIPTION
The word "Shortcuts" was being hidden behind the buttons, this makes the text a tiny bit smaller so it fits.
